### PR TITLE
Add void return attribute to _initialize()

### DIFF
--- a/src/Codeception.php
+++ b/src/Codeception.php
@@ -22,7 +22,7 @@ class Codeception extends \Codeception\Extension
     private $apiKey;
     private $hasFailed = false;
 
-    public function _initialize()
+    public function _initialize(): void
     {
         error_reporting(E_ALL & ~E_DEPRECATED); // http library incompatible
         $this->url = trim(getenv('TESTOMATIO_URL'));


### PR DESCRIPTION
Running

```
TESTOMATIO=1234567890 vendor/bin/codecept run --ext "Testomatio\Reporter\Codeception"
```

results in 

```
PHP Fatal error:  Declaration of Testomatio\Reporter\Codeception::_initialize() must be compatible with Codeception\Extension::_initialize(): void in .../vendor/testomatio/reporter/src/Codeception.php on line 25
```

Fixes #3 